### PR TITLE
set apiUrl for Vercel deploy

### DIFF
--- a/redwood.toml
+++ b/redwood.toml
@@ -8,7 +8,7 @@
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # you can customise graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  apiUrl = "/api" # you can customise graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://redwoodjs.com/docs/environment-variables#web
 [api]
   port = 8911


### PR DESCRIPTION
Vercel requires a specific API endpoint for Vercel Functions. The easiest way to set this is `yarn rw setup deploy vercel`. I've added it manually.

This should fix the deploy.